### PR TITLE
Stop alarm noise if back button is pressed or notification is swiped

### DIFF
--- a/app/src/main/java/com/pillpals/pillpals/services/AlarmReceiver.kt
+++ b/app/src/main/java/com/pillpals/pillpals/services/AlarmReceiver.kt
@@ -81,6 +81,10 @@ public class AlarmReceiver: BroadcastReceiver() {
                 drawable.setBounds((drawable.intrinsicWidth * 0.1).toInt(), (drawable.intrinsicWidth * 0.1).toInt(), iconCanvas.width - (drawable.intrinsicWidth * 0.1).toInt(), iconCanvas.height - (drawable.intrinsicWidth * 0.1).toInt())
                 drawable.draw(iconCanvas)
 
+                var stopNoiseIntent = Intent(context, this::class.java)
+                stopNoiseIntent.putExtra("stop-noise", true)
+                var pendingStopNoiseIntent = PendingIntent.getBroadcast(context, -2, stopNoiseIntent, 0)
+
                 // Set the notification content
                 val mBuilder = NotificationCompat.Builder(context, context.getString(R.string.channel_id_rich))
                     .setSmallIcon(getDrawable(privateMode))
@@ -88,6 +92,7 @@ public class AlarmReceiver: BroadcastReceiver() {
                     .setPriority(priorityValue)
                     .setLargeIcon(iconBitmap)
                     .setTicker(getTickerString(privateMode, sharedPreferences))
+                    .setDeleteIntent(pendingStopNoiseIntent)
 
 
                 if(medication.notes.isNotEmpty() && !privateMode) {

--- a/app/src/main/java/com/pillpals/pillpals/ui/AlarmActivity.kt
+++ b/app/src/main/java/com/pillpals/pillpals/ui/AlarmActivity.kt
@@ -107,6 +107,12 @@ class AlarmActivity : AppCompatActivity() {
         }
     }
 
+    override fun onBackPressed() {
+        PillPalsApplication.alarmNoiseHelper.stopNoise()
+
+        super.onBackPressed()
+    }
+
     private fun setupViewVars() {
         message = findViewById(R.id.alarmMessage)
         iconCard = findViewById(R.id.alarmIconBackground)


### PR DESCRIPTION
I think this _should_ cover the remaining cases that would cause logging the dose to be the only way to stop the alarm noise.  It's still technically possible to get out of the full screen alarm without stopping the noise by hitting the home or recent apps buttons, but those are more difficult to address and the user is now still able to swipe the notification to silence it.