### PR TITLE
Repeating alarm and other fixes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -61,11 +61,15 @@
 
         <receiver
             android:name=".services.AlarmReceiver"
-            android:process=":remote" />
+            android:process=":remote"
+            android:enabled="true"
+            android:directBootAware="true"
+            />
         <receiver
             android:name=".services.BootupReceiver"
             android:enabled="true"
-            android:exported="true">
+            android:exported="true"
+            android:directBootAware="true">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.intent.action.QUICKBOOT_POWERON" />

--- a/app/src/main/java/com/pillpals/pillpals/helpers/GenericHelpers.kt
+++ b/app/src/main/java/com/pillpals/pillpals/helpers/GenericHelpers.kt
@@ -85,7 +85,7 @@ public fun drawableToBitmap(drawable: Drawable): Bitmap? {
     return bitmap
 }
 
-public fun drugLogFunction(schedule: Schedules, context: Context, time: Date = Date()) {
+public fun drugLogFunction(schedule: Schedules, context: Context, time: Date = Calendar.getInstance().time) {
     val realm = Realm.getDefaultInstance()
 
     val databaseSchedule =

--- a/app/src/main/java/com/pillpals/pillpals/helpers/NotificationUtil.kt
+++ b/app/src/main/java/com/pillpals/pillpals/helpers/NotificationUtil.kt
@@ -35,7 +35,7 @@ class NotificationUtils {
 //            }
 
             while (scheduleTime!! < DateHelper.yesterdayAt12pm()) {
-                scheduleTime = DateHelper.addUnitToDate(scheduleTime, schedule.repetitionCount!!, schedule.repetitionUnit!!)
+                scheduleTime = DateHelper.addUnitToDate(scheduleTime, schedule.repetitionCount!!, DateHelper.getUnitByIndex(schedule.repetitionUnit!!))
             }
 
             c.time = scheduleTime
@@ -43,9 +43,10 @@ class NotificationUtils {
 
             val am = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
             val interval = DateHelper.getMillisecondsByUnit(
-                schedule.repetitionUnit!!
+                DateHelper.getUnitByIndex(schedule.repetitionUnit!!)
             ) * schedule.repetitionCount!!
             am.setRepeating(AlarmManager.RTC_WAKEUP, firstTime, interval, mAlarmSender)
+//            am.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, firstTime, mAlarmSender)
         }
 
         fun updateAlarms(context: Context) {
@@ -59,7 +60,7 @@ class NotificationUtils {
             }
         }
 
-        private fun getPendingIntent(context: Context, schedule: Schedules) : PendingIntent {
+        fun getPendingIntent(context: Context, schedule: Schedules, uid: Int = schedule.uid!!.hashCode()) : PendingIntent {
             val intent = Intent(context, AlarmReceiver::class.java)
             intent.putExtra("schedule-uid", schedule.uid)
             intent.putExtra("schedule-occurrence", DateHelper.convertToLocalDateViaInstant(schedule.occurrence!!).toString())
@@ -67,7 +68,7 @@ class NotificationUtils {
 
             return PendingIntent.getBroadcast(
                 context,
-                schedule.uid!!.hashCode(),
+                uid,
                 intent,
                 0
             )
@@ -77,7 +78,7 @@ class NotificationUtils {
             val notificationManager = NotificationManagerCompat.from(context)
             notificationManager.cancel(schedule.uid.hashCode())
 
-            val mAlarmSender = getPendingIntent(context, schedule)
+            val mAlarmSender = getPendingIntent(context, schedule, (schedule.uid!! + "alarm_snooze").hashCode())
 
             var c = Calendar.getInstance()
             var snoozeTime = DateHelper.addUnitToDate(c.time, 15, Calendar.MINUTE) //TODO: Make snooze time editable

--- a/app/src/main/java/com/pillpals/pillpals/helpers/NotificationUtil.kt
+++ b/app/src/main/java/com/pillpals/pillpals/helpers/NotificationUtil.kt
@@ -42,11 +42,11 @@ class NotificationUtils {
             val firstTime = c.timeInMillis
 
             val am = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
-            val interval = DateHelper.getMillisecondsByUnit(
-                DateHelper.getUnitByIndex(schedule.repetitionUnit!!)
-            ) * schedule.repetitionCount!!
-            am.setRepeating(AlarmManager.RTC_WAKEUP, firstTime, interval, mAlarmSender)
-//            am.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, firstTime, mAlarmSender)
+//            val interval = DateHelper.getMillisecondsByUnit(
+//                DateHelper.getUnitByIndex(schedule.repetitionUnit!!)
+//            ) * schedule.repetitionCount!!
+//            am.setRepeating(AlarmManager.RTC_WAKEUP, firstTime, interval, mAlarmSender)
+            am.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, firstTime, mAlarmSender)
         }
 
         fun updateAlarms(context: Context) {
@@ -65,6 +65,7 @@ class NotificationUtils {
             intent.putExtra("schedule-uid", schedule.uid)
             intent.putExtra("schedule-occurrence", DateHelper.convertToLocalDateViaInstant(schedule.occurrence!!).toString())
             intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES)
+            intent.addFlags(Intent.FLAG_RECEIVER_FOREGROUND)
 
             return PendingIntent.getBroadcast(
                 context,

--- a/app/src/main/java/com/pillpals/pillpals/services/AlarmReceiver.kt
+++ b/app/src/main/java/com/pillpals/pillpals/services/AlarmReceiver.kt
@@ -146,7 +146,7 @@ public class AlarmReceiver: BroadcastReceiver() {
                     notification.flags = notification.flags or Notification.FLAG_INSISTENT
                 }
 
-//                setupNextAlarm(context, schedule)
+                setupNextAlarm(context, schedule)
 
                 // notificationId is a unique int for each notification that you must define
                 notificationManager.notify(schedule.uid!!.hashCode(), mBuilder.build())

--- a/app/src/main/java/com/pillpals/pillpals/services/AlarmReceiver.kt
+++ b/app/src/main/java/com/pillpals/pillpals/services/AlarmReceiver.kt
@@ -24,6 +24,7 @@ import com.pillpals.pillpals.PillPalsApplication
 import com.pillpals.pillpals.helpers.AlarmNoiseHelper
 import com.pillpals.pillpals.helpers.DatabaseHelper.Companion.getColorStringByID
 import com.pillpals.pillpals.helpers.DatabaseHelper.Companion.getCorrectIconDrawable
+import com.pillpals.pillpals.helpers.NotificationUtils
 import com.pillpals.pillpals.ui.AlarmActivity
 
 
@@ -58,8 +59,8 @@ public class AlarmReceiver: BroadcastReceiver() {
             }
             if(!sharedPreferences.getBoolean("notifications", false)) {
                 val medication = schedule.medication!!.first() as Medications
-                val occurrenceLocal = LocalDateTime.parse(intent.getStringExtra("schedule-occurrence"))
-                val occurrence = Date.from(occurrenceLocal.atZone(ZoneId.systemDefault()).toInstant())
+                val occurrenceAtZone = schedule.occurrence!!.toInstant().atZone(ZoneId.systemDefault())
+                val occurrence = Date.from(occurrenceAtZone.toInstant())
 
                 val title = getTitleString(medication, privateMode, occurrence, sharedPreferences)
 
@@ -145,12 +146,26 @@ public class AlarmReceiver: BroadcastReceiver() {
                     notification.flags = notification.flags or Notification.FLAG_INSISTENT
                 }
 
+//                setupNextAlarm(context, schedule)
+
                 // notificationId is a unique int for each notification that you must define
                 notificationManager.notify(schedule.uid!!.hashCode(), mBuilder.build())
 
                 //setupAutoCancel(context, intent, schedule, 15, Calendar.MINUTE) //TODO: Refine this end time
             }
         }
+    }
+
+    private fun setupNextAlarm(context: Context, schedule: Schedules) {
+        val am = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        am.cancel(NotificationUtils.getPendingIntent(context, schedule))
+        val interval = DateHelper.getMillisecondsByUnit(
+            DateHelper.getUnitByIndex(schedule.repetitionUnit!!)
+        ) * schedule.repetitionCount!!
+        val c = Calendar.getInstance()
+        c.time = schedule.occurrence!!
+        val nextTime = c.timeInMillis + interval
+        am.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, nextTime, NotificationUtils.getPendingIntent(context, schedule))
     }
 
     private fun setupAutoCancel(context: Context, intent: Intent, schedule: Schedules, time: Int, unit: Int) {

--- a/app/src/main/java/com/pillpals/pillpals/ui/AlarmActivity.kt
+++ b/app/src/main/java/com/pillpals/pillpals/ui/AlarmActivity.kt
@@ -95,7 +95,7 @@ class AlarmActivity : AppCompatActivity() {
             }
 
             openButton.setOnClickListener {
-                alarmSnoozeFunc(schedule)
+//                alarmSnoozeFunc(schedule)
                 alarmOpenFunc()
             }
 
@@ -139,6 +139,7 @@ class AlarmActivity : AppCompatActivity() {
     }
 
     private fun alarmOpenFunc() {
+        PillPalsApplication.alarmNoiseHelper.stopNoise()
         var newIntent = Intent(this, MainActivity::class.java)
         startActivity(newIntent)
     }

--- a/app/src/main/java/com/pillpals/pillpals/ui/EditScheduleActivity.kt
+++ b/app/src/main/java/com/pillpals/pillpals/ui/EditScheduleActivity.kt
@@ -222,6 +222,8 @@ class EditScheduleActivity : AppCompatActivity() {
                                 schedule.startDate = it.time
                                 schedule.repetitionCount = 1
                                 schedule.repetitionUnit = 2
+//                                schedule.repetitionCount = 5 //For testing (5 minute interval)
+//                                schedule.repetitionUnit = 4
                                 schedules.add(schedule)
                             }
                         } else {

--- a/app/src/main/java/com/pillpals/pillpals/ui/dashboard/DashboardFragment.kt
+++ b/app/src/main/java/com/pillpals/pillpals/ui/dashboard/DashboardFragment.kt
@@ -1160,7 +1160,7 @@ class DashboardFragment : Fragment() {
 
             for (i in moodLogs.indices) {
                 var cal = Calendar.getInstance()
-                cal.time = DateHelper.addUnitToDate(Date(),dates[i],DateHelper.getIndexByUnit(Calendar.DATE))
+                cal.time = DateHelper.addUnitToDate(Date(),dates[i],Calendar.DATE)
                 cal.set(Calendar.MILLISECOND, 0)
                 cal.set(Calendar.SECOND, 0)
                 cal.set(Calendar.MINUTE, 0)


### PR DESCRIPTION
- Changed alarms to use chained single-use alarms instead of repeating and added a flag to the intents to hopefully improve the notification priority when phone is dozing
- Fixed current time in drugLogFunction
- Fixed time units in some DateHelper function calls (primarily for calculating notification intervals)
- Fixed PendingIntent UIDs being the same for notification and snooze requests
- Fixed alarm text only showing initial schedule time
- Made "Open PillPals" button just silence the alarm, not snooze it